### PR TITLE
Hack to get pushing person into service provider

### DIFF
--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -20,7 +20,8 @@ class ServiceProvidersController < ApplicationController
   def add_person
     uuid = params[:uuid]
     @person = Person.find_by_uuid(uuid)
-    @service_provider.clients << @person
+    @service_provider.person.push(@person)
+    @service_provider.save
     redirect_to @person, notice: @person.first_name + ' ' + @person.last_name + ' was added to your client list.'
   end
 

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -5,7 +5,7 @@ class ServiceProvider
     key :services_supplies, String
     key :clients, Array
    
-   many :persons, :in => :clients
+   many :person, :in => :clients
     one :authenticable, :class_name => "Authenticable", :as => :authenticable_object
     
     timestamps!

--- a/app/views/service_providers/show.html.erb
+++ b/app/views/service_providers/show.html.erb
@@ -46,7 +46,7 @@
     </thead>
 
     <tbody>
-    <% @service_provider.clients.each do |person| %>
+    <% @service_provider.person.each do |person| %>
       <tr>
         <td><%= link_to person.name, person %></td>
         <td><%= person.dob %></td>


### PR DESCRIPTION
This change works around what appears to be a problem reported by other users of mongo mapper. The field "clients" of service provider should provide access to the "clients" of the service provider but the term "person" seems to work. 
